### PR TITLE
Added bf16 convert proposal

### DIFF
--- a/proposals/bf16-convert-proposal.adoc
+++ b/proposals/bf16-convert-proposal.adoc
@@ -1,0 +1,60 @@
+:sectnums:
+
+= Bfloat16 ⇄ Float32 Conversions
+
+_Warning! This draft proposal has not been officially endorsed or accepted by RISC-V International._
+
+This document proposes instructions that convert between Bfloat16 (BF16) and IEEE 754 single-precision (FP32) values.
+
+A motivating use-case is a control processor,
+which performs these conversions in concert with an accelerator operating on the BF16 values.
+
+This document does not address BF16 arithmetic beyond these conversions.
+For example, arithmetic performed on converted BF16 values may flush subnormals,
+use odd rounding, ignore exceptions, etc.
+
+== Zfhbfmin (Scalar Conversions)
+
+The *Zfhbfmin* extension adds scalar conversions between BF16 and FP32:
+
+----
+fcvt.s.bf16  # Convert BF16 to FP32
+fcvt.bf16.s  # Convert FP32 to BF16
+----
+
+These instructions behave identically to the Zfh-extension instructions `fcvt.s.h` and `fcvt.h.s`, resp.,
+except that the narrower operands encode BF16 values instead of IEEE 754 half-precision (FP16) values.
+In particular, they obey the (static or dynamic) rounding mode,
+set floating-point exception flags, and generate special values as appropriate.
+BF16 values are stored, NaN-boxed, in F registers,
+analogously to FP16 values in the Zfh extension.
+
+The Zfhbfmin extension depends on the F extension.
+
+The Zfhbfmin extension also includes four instructions from the Zfhmin extension,
+`flh`, `fsh`, `fmv.x.h`, and `fmv.h.x`.
+These instructions copy bit patterns without interpreting them,
+so their semantics are equivalent for FP16 and BF16.
+
+== Zvfhbfmin (Vector Conversions)
+
+The *Zvfhbfmin* extension provides the vector analogues of the scalar conversions:
+
+----
+vfwcvt.f.bf16.v  # source EEW=16, dest. EEW=32
+vfncvt.bf16.f.w  # source EEW=32, dest. EEW=16
+----
+
+These instructions behave like SEW=16 analogues of the V-extension `vfwcvt.f.f.v` and `vfncvt.f.f.w` instructions, resp.,
+except that they are encoded with `vs1=01101` and `vs1=11101`, resp., and
+the narrower operands encode BF16 numbers.
+Like the scalar versions, they obey the dynamic rounding mode,
+set floating-point exception flags, and generate special values as appropriate.
+These instructions are reserved if SEW≠16.
+
+The Zvfhbfmin extension depends on the Zve32f extension.
+
+The Zvfhbfmin extension also adds SEW=16 forms of four Zve32f instructions,
+`vfmv.f.s`, `vfmv.s.f`, `vfslide1up.vf`, and `vfslide1down.vf`.
+These instructions copy bit patterns without interpreting them,
+so their semantics are equivalent for FP16 and BF16.


### PR DESCRIPTION
[Note: since this repository is not widely watched, I will be sending a similar message to the TG mailing list.]

A common theme in this task group from the outset has been distinguishing different degrees of BF16 support:

(1) Conversions between BF16 and "native" types (like FP32);
(2) Basic support for BF16 linear algebra, namely FMAs, dot products, and matrix multiplications more generally; and
(3) Comprehensive BF16 arithmetic, either matching existing FP support, or with AI-specific bells and whistles.

At SiFive we've seen a similar classification in interest/requests from our customers, and think it is best to separate the concerns of these use-cases.

This PR shares SiFive's proposal for use-case (1), i.e., conversions. (It does not address the other two use-cases.)

Your feedback is welcome.

Best,
Nick Knight (acting co-chair),
SiFive, Inc.